### PR TITLE
Tweak posting row item widths to make currency a bit wider

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/ui/add/AddActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/add/AddActivity.kt
@@ -364,28 +364,28 @@ fun PostingRow(
     addViewModel: AddViewModel = viewModel(),
 ) {
     val currencyBeforeAmount by addViewModel.currencyBeforeAmount.observeAsState()
-    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp, horizontal = 4.dp)) {
         AccountSelector(
             index = index,
             value = posting.first,
-            modifier = Modifier.weight(0.57f).padding(start = 4.dp, end = 2.dp),
+            modifier = Modifier.weight(2f),
         )
         if (currencyBeforeAmount ?: true) {
-            CurrencyField(index, posting, Modifier.weight(0.18f))
+            CurrencyField(index, posting, Modifier.weight(0.9f).padding(horizontal = 4.dp))
             AmountField(
                 index,
                 posting,
                 firstEmptyAmount,
-                Modifier.weight(0.25f).padding(start = 2.dp, end = 4.dp),
+                Modifier.weight(1.3f),
             )
         } else {
             AmountField(
                 index,
                 posting,
                 firstEmptyAmount,
-                Modifier.weight(0.25f).padding(horizontal = 2.dp),
+                Modifier.weight(1.3f).padding(horizontal = 4.dp),
             )
-            CurrencyField(index, posting, Modifier.weight(0.18f))
+            CurrencyField(index, posting, Modifier.weight(0.9f))
         }
     }
 }

--- a/app/src/main/java/be/chvp/nanoledger/ui/add/AddActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/add/AddActivity.kt
@@ -371,7 +371,7 @@ fun PostingRow(
             modifier = Modifier.weight(0.57f).padding(start = 4.dp, end = 2.dp),
         )
         if (currencyBeforeAmount ?: true) {
-            CurrencyField(index, posting, Modifier.weight(0.18f).padding(horizontal = 2.dp))
+            CurrencyField(index, posting, Modifier.weight(0.18f))
             AmountField(
                 index,
                 posting,
@@ -385,7 +385,7 @@ fun PostingRow(
                 firstEmptyAmount,
                 Modifier.weight(0.25f).padding(horizontal = 2.dp),
             )
-            CurrencyField(index, posting, Modifier.weight(0.18f).padding(start = 2.dp, end = 4.dp))
+            CurrencyField(index, posting, Modifier.weight(0.18f))
         }
     }
 }

--- a/app/src/main/java/be/chvp/nanoledger/ui/add/AddActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/add/AddActivity.kt
@@ -364,28 +364,28 @@ fun PostingRow(
     addViewModel: AddViewModel = viewModel(),
 ) {
     val currencyBeforeAmount by addViewModel.currencyBeforeAmount.observeAsState()
-    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp, horizontal = 4.dp)) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp, horizontal = 2.dp)) {
         AccountSelector(
             index = index,
             value = posting.first,
-            modifier = Modifier.weight(2f),
+            modifier = Modifier.weight(2.2f).padding(horizontal = 2.dp),
         )
         if (currencyBeforeAmount ?: true) {
-            CurrencyField(index, posting, Modifier.weight(0.9f).padding(horizontal = 4.dp))
+            CurrencyField(index, posting, Modifier.weight(0.95f).padding(horizontal = 2.dp))
             AmountField(
                 index,
                 posting,
                 firstEmptyAmount,
-                Modifier.weight(1.3f),
+                Modifier.weight(1.25f).padding(horizontal = 2.dp),
             )
         } else {
             AmountField(
                 index,
                 posting,
                 firstEmptyAmount,
-                Modifier.weight(1.3f).padding(horizontal = 4.dp),
+                Modifier.weight(1.25f).padding(horizontal = 2.dp),
             )
-            CurrencyField(index, posting, Modifier.weight(0.9f))
+            CurrencyField(index, posting, Modifier.weight(0.95f).padding(horizontal = 2.dp))
         }
     }
 }


### PR DESCRIPTION
On a Nothing Phone 1, on the Add transaction screen the currency were not
visible because the left and right paddings added too much empty space to the
text field and it just scrolled out from the view.

Removed the the padding from the currency field as the it is already aligend to
the center. The padding is not needed, the spacing will be evenly distributed
before and after the text.


Uploaded the fixed version to my phone, opened the "Add transaction" action. My
predefined currency were visible and no scrolling were needed anymore.
