### PR TITLE
Allow deleting transactions

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
@@ -42,7 +42,7 @@ class LedgerRepository
             fileUri: Uri,
             transaction: Transaction,
             onFinish: suspend () -> Unit,
-            onMismatch: suspend() -> Unit,
+            onMismatch: suspend () -> Unit,
             onWriteError: suspend (IOException) -> Unit,
             onReadError: suspend (IOException) -> Unit,
         ) {

--- a/app/src/main/java/be/chvp/nanoledger/data/Transaction.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/Transaction.kt
@@ -8,6 +8,8 @@ data class Posting(
 }
 
 data class Transaction(
+    val firstLine: Int,
+    val lastLine: Int,
     val date: String,
     val status: String?,
     val payee: String,

--- a/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
@@ -16,6 +16,8 @@ fun extractTransactions(lines: List<String>): List<Transaction> {
         val match = headerRegex.find(lines[i])
         i += 1
         if (match != null) {
+            val firstLine = i - 1
+            var lastLine = i - 1
             val groups = match.groups
             val date = groups[1]!!.value
             val status = groups[5]?.value
@@ -27,6 +29,7 @@ fun extractTransactions(lines: List<String>): List<Transaction> {
                 val stripped = lines[i].trim().replace(commentRegex, "")
                 i += 1
                 if (stripped.length > 0) {
+                    lastLine = i - 1
                     val components = stripped.split(postingSplitRegex, limit = 2)
                     if (components.size > 1) {
                         postings.add(Posting(components[0], components[1]))
@@ -35,7 +38,7 @@ fun extractTransactions(lines: List<String>): List<Transaction> {
                     }
                 }
             }
-            result.add(Transaction(date, status, payee, note, postings))
+            result.add(Transaction(firstLine, lastLine, date, status, payee, note, postings))
         }
     }
     return result

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/MainActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/MainActivity.kt
@@ -22,9 +22,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -76,15 +78,44 @@ class MainActivity : ComponentActivity() {
         setContent {
             val context = LocalContext.current
             val searching by mainViewModel.searching.observeAsState()
-            val latestError by mainViewModel.latestError.observeAsState()
-            val errorMessage = stringResource(R.string.error_reading_file)
-            LaunchedEffect(latestError) {
-                val error = latestError?.get()
+            val selected by mainViewModel.selectedIndex.observeAsState()
+
+            val latestReadError by mainViewModel.latestReadError.observeAsState()
+            val readErrorMessage = stringResource(R.string.error_reading_file)
+            LaunchedEffect(latestReadError) {
+                val error = latestReadError?.get()
                 if (error != null) {
                     Log.e("be.chvp.nanoledger", "Exception while reading file", error)
                     Toast.makeText(
                         context,
-                        errorMessage,
+                        readErrorMessage,
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+            }
+
+            val latestWriteError by mainViewModel.latestWriteError.observeAsState()
+            val writeErrorMessage = stringResource(R.string.error_writing_file)
+            LaunchedEffect(latestWriteError) {
+                val error = latestWriteError?.get()
+                if (error != null) {
+                    Log.e("be.chvp.nanoledger", "Exception while writing file", error)
+                    Toast.makeText(
+                        context,
+                        writeErrorMessage,
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+            }
+
+            val latestMismatch by mainViewModel.latestMismatch.observeAsState()
+            val mismatchMessage = stringResource(R.string.mismatch_no_delete)
+            LaunchedEffect(latestMismatch) {
+                val error = latestMismatch?.get()
+                if (error != null) {
+                    Toast.makeText(
+                        context,
+                        mismatchMessage,
                         Toast.LENGTH_LONG,
                     ).show()
                 }
@@ -97,7 +128,9 @@ class MainActivity : ComponentActivity() {
             NanoLedgerTheme {
                 Scaffold(
                     topBar = {
-                        if (searching ?: false) {
+                        if (selected != null) {
+                            SelectionBar()
+                        } else if (searching ?: false) {
                             SearchBar()
                         } else {
                             MainBar()
@@ -176,6 +209,7 @@ fun MainContent(
     val transactions by mainViewModel.filteredTransactions.observeAsState()
     val query by mainViewModel.query.observeAsState()
     val isRefreshing by mainViewModel.isRefreshing.observeAsState()
+    val selected by mainViewModel.selectedIndex.observeAsState()
     val state = rememberPullToRefreshState()
     if (state.isRefreshing && !(isRefreshing ?: false)) {
         LaunchedEffect(true) {
@@ -199,50 +233,71 @@ fun MainContent(
         if ((transactions?.size ?: 0) > 0 || (isRefreshing ?: true)) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(transactions?.size ?: 0) {
-                    val tr = transactions!![transactions!!.size - it - 1]
+                    val index = transactions!!.size - it - 1
                     Card(
+                        colors =
+                            if (index == selected) {
+                                CardDefaults.outlinedCardColors()
+                            } else {
+                                CardDefaults.cardColors()
+                            },
+                        elevation =
+                            if (index == selected) {
+                                CardDefaults.outlinedCardElevation()
+                            } else {
+                                CardDefaults.cardElevation()
+                            },
+                        border =
+                            if (index == selected) {
+                                CardDefaults.outlinedCardBorder(true)
+                            } else {
+                                null
+                            },
                         modifier =
                             Modifier.fillMaxWidth().padding(
                                 8.dp,
                                 if (it == 0) 8.dp else 4.dp,
                                 8.dp,
                                 if (it == transactions!!.size - 1) 8.dp else 4.dp,
-                            ).clickable { mainViewModel.deleteTransaction(tr) },
+                            ),
                     ) {
-                        Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
-                            Text(
-                                transactionHeader(tr),
-                                softWrap = false,
-                                style =
-                                    MaterialTheme.typography.bodySmall.copy(
-                                        fontFamily = FontFamily.Monospace,
-                                    ),
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            for (p in tr.postings) {
-                                Row(
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    modifier = Modifier.fillMaxWidth(),
-                                ) {
-                                    Text(
-                                        "  ${p.account}",
-                                        softWrap = false,
-                                        style =
-                                            MaterialTheme.typography.bodySmall.copy(
-                                                fontFamily = FontFamily.Monospace,
-                                            ),
-                                        overflow = TextOverflow.Ellipsis,
-                                        modifier = Modifier.weight(1f),
-                                    )
-                                    Text(
-                                        p.amount ?: "",
-                                        softWrap = false,
-                                        style =
-                                            MaterialTheme.typography.bodySmall.copy(
-                                                fontFamily = FontFamily.Monospace,
-                                            ),
-                                        modifier = Modifier.padding(start = 2.dp),
-                                    )
+                        Box(modifier = Modifier.clickable { mainViewModel.toggleSelect(index) }) {
+                            val tr = transactions!![index]
+                            Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+                                Text(
+                                    transactionHeader(tr),
+                                    softWrap = false,
+                                    style =
+                                        MaterialTheme.typography.bodySmall.copy(
+                                            fontFamily = FontFamily.Monospace,
+                                        ),
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                for (p in tr.postings) {
+                                    Row(
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        modifier = Modifier.fillMaxWidth(),
+                                    ) {
+                                        Text(
+                                            "  ${p.account}",
+                                            softWrap = false,
+                                            style =
+                                                MaterialTheme.typography.bodySmall.copy(
+                                                    fontFamily = FontFamily.Monospace,
+                                                ),
+                                            overflow = TextOverflow.Ellipsis,
+                                            modifier = Modifier.weight(1f),
+                                        )
+                                        Text(
+                                            p.amount ?: "",
+                                            softWrap = false,
+                                            style =
+                                                MaterialTheme.typography.bodySmall.copy(
+                                                    fontFamily = FontFamily.Monospace,
+                                                ),
+                                            modifier = Modifier.padding(start = 2.dp),
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -318,6 +373,40 @@ fun MainBar(mainViewModel: MainViewModel = viewModel()) {
                 actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
             ),
     )
+}
+
+@Composable
+fun SelectionBar(mainViewModel: MainViewModel = viewModel()) {
+    val selected by mainViewModel.selectedIndex.observeAsState()
+    TopAppBar(
+        navigationIcon = {
+            IconButton(
+                onClick = {
+                    mainViewModel.toggleSelect(selected!!)
+                },
+                modifier = Modifier.padding(start = 8.dp),
+            ) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.stop_selection))
+            }
+        },
+        title = { },
+        actions = {
+            IconButton(onClick = { mainViewModel.deleteSelected() }) {
+                Icon(Icons.Filled.Delete, contentDescription = stringResource(R.string.delete))
+            }
+        },
+        colors =
+            TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            ),
+    )
+
+    BackHandler {
+        mainViewModel.toggleSelect(selected!!)
+    }
 }
 
 @Composable

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/MainActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/MainActivity.kt
@@ -199,6 +199,7 @@ fun MainContent(
         if ((transactions?.size ?: 0) > 0 || (isRefreshing ?: true)) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(transactions?.size ?: 0) {
+                    val tr = transactions!![transactions!!.size - it - 1]
                     Card(
                         modifier =
                             Modifier.fillMaxWidth().padding(
@@ -206,9 +207,8 @@ fun MainContent(
                                 if (it == 0) 8.dp else 4.dp,
                                 8.dp,
                                 if (it == transactions!!.size - 1) 8.dp else 4.dp,
-                            ),
+                            ).clickable { mainViewModel.deleteTransaction(tr) },
                     ) {
-                        val tr = transactions!![transactions!!.size - it - 1]
                         Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
                             Text(
                                 transactionHeader(tr),

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/MainViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/MainViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import be.chvp.nanoledger.data.LedgerRepository
 import be.chvp.nanoledger.data.PreferencesDataSource
+import be.chvp.nanoledger.data.Transaction
 import be.chvp.nanoledger.ui.util.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers.IO
@@ -50,16 +51,42 @@ class MainViewModel
         val latestError: LiveData<Event<IOException>?> = _latestError
 
         fun refresh() {
-            _isRefreshing.value = true
-            viewModelScope.launch(IO) {
-                ledgerRepository.readFrom(
-                    preferencesDataSource.getFileUri(),
-                    { _isRefreshing.postValue(false) },
-                    {
-                        _isRefreshing.postValue(false)
-                        _latestError.postValue(Event(it))
-                    },
-                )
+            val uri = preferencesDataSource.getFileUri()
+            if (uri != null) {
+                _isRefreshing.value = true
+                viewModelScope.launch(IO) {
+                    ledgerRepository.readFrom(
+                        uri,
+                        { _isRefreshing.postValue(false) },
+                        {
+                            _isRefreshing.postValue(false)
+                            _latestError.postValue(Event(it))
+                        },
+                    )
+                }
+            }
+        }
+
+        fun deleteTransaction(transaction: Transaction) {
+            val uri = preferencesDataSource.getFileUri()
+            if (uri != null) {
+                _isRefreshing.value = true
+                viewModelScope.launch(IO) {
+                    ledgerRepository.deleteTransaction(
+                        uri,
+                        transaction,
+                        {},
+                        { _isRefreshing.postValue(false) },
+                        {
+                            _isRefreshing.postValue(false)
+                            _latestError.postValue(Event(it))
+                        },
+                        {
+                            _isRefreshing.postValue(false)
+                            _latestError.postValue(Event(it))
+                        },
+                    )
+                }
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,10 +13,12 @@
     <string name="date">Date</string>
     <string name="default_currency">Default currency</string>
     <string name="default_status">Default status</string>
+    <string name="delete">Delete</string>
     <string name="dismiss">Dismiss</string>
     <string name="error">Error</string>
     <string name="error_reading_file">Error while reading file</string>
     <string name="error_writing_file">Error while writing file</string>
+    <string name="mismatch_no_delete">File contents outdated, aborting delete</string>
     <string name="file">File</string>
     <string name="note">Note</string>
     <string name="ok">OK</string>
@@ -28,6 +30,8 @@
     <string name="status_cleared">Cleared (*)</string>
     <string name="status_pending">Pending (!)</string>
     <string name="status_unmarked">Unmarked</string>
+
+    <string name="stop_selection">Stop selection</string>
 
     <string name="no_file_yet">You don&#8217;t have a file configured yet.</string>
     <string name="go_to_settings">Go to the settings to configure one.</string>

--- a/app/src/test/java/be/chvp/nanoledger/data/parser/TransactionParserTest.kt
+++ b/app/src/test/java/be/chvp/nanoledger/data/parser/TransactionParserTest.kt
@@ -19,6 +19,8 @@ class TransactionParserTest {
         assertEquals(1, result.size)
         val transaction: Transaction = result[0]
 
+        assertEquals(0, transaction.firstLine)
+        assertEquals(2, transaction.lastLine)
         assertEquals("2023-08-31", transaction.date)
         assertEquals("*", transaction.status)
         assertEquals("Payee", transaction.payee)
@@ -44,6 +46,8 @@ class TransactionParserTest {
         assertEquals(1, result.size)
         val transaction: Transaction = result[0]
 
+        assertEquals(0, transaction.firstLine)
+        assertEquals(2, transaction.lastLine)
         assertEquals("2023-08-31", transaction.date)
         assertEquals("*", transaction.status)
         assertEquals("Payee", transaction.payee)
@@ -71,6 +75,8 @@ class TransactionParserTest {
             )
 
         assertEquals(2, transactions.size)
+        assertEquals(0, transactions[0].firstLine)
+        assertEquals(2, transactions[0].lastLine)
         assertEquals("2023-08-31", transactions[0].date)
         assertEquals("*", transactions[0].status)
         assertEquals("Payee", transactions[0].payee)
@@ -81,6 +87,8 @@ class TransactionParserTest {
         assertEquals("expenses", transactions[0].postings[1].account)
         assertEquals("€ 5.00", transactions[0].postings[1].amount)
 
+        assertEquals(3, transactions[1].firstLine)
+        assertEquals(6, transactions[1].lastLine)
         assertEquals("2023-09-01", transactions[1].date)
         assertEquals("*", transactions[1].status)
         assertEquals("Payee 2", transactions[1].payee)


### PR DESCRIPTION
Deleting can be done by tapping on a transaction (which selects it). This changes the toolbar so that a delete button becomes visible. Selection can be undone by tapping the transaction again, pressing the back button, or tapping the back icon in the toolbar.

Fixes #48.

