### PR TITLE
Disable android gradle plugin version lint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ android {
         quiet = true
         disable.addAll(
             arrayOf(
+                "AndroidGradlePluginVersion",
                 "GradleDependency",
                 "NewerVersionAvailable",
                 "ObsoleteLintCustomCheck",


### PR DESCRIPTION
Lints should not break CI just because time has passed.
