### PR TITLE
Allow configuring decimal separator and ignore any other grouping separators

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/data/PreferencesDataSource.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/PreferencesDataSource.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 const val FILE_URI_KEY = "file_uri"
+const val DECIMAL_SEPARATOR_KEY = "decimal_separator"
 const val DEFAULT_CURRENCY_KEY = "default_currency"
 const val DEFAULT_STATUS_KEY = "default_status"
 const val CURRENCY_BEFORE_AMOUNT_KEY = "currency_before_amount"
@@ -63,6 +64,12 @@ class PreferencesDataSource
                 DEFAULT_STATUS_KEY,
                 status,
             ).apply()
+
+        val decimalSeparator: LiveData<String> = sharedPreferences.stringLiveData(DECIMAL_SEPARATOR_KEY, ".").map { it!! }
+
+        fun getDecimalSeparator(): String = sharedPreferences.getString(DECIMAL_SEPARATOR_KEY, ".")!!
+
+        fun setDecimalSeparator(separator: String) = sharedPreferences.edit().putString(DECIMAL_SEPARATOR_KEY, separator).apply()
 
         val currencyBeforeAmount: LiveData<Boolean> =
             sharedPreferences.booleanLiveData(

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -72,15 +72,29 @@ abstract class TransactionFormViewModel
                     .map { it.third }
                     .filter { it != "" }
                     .map {
+                        val cleaned =
+                            it.replace(
+                                Regex("[^-0-9${preferencesDataSource.getDecimalSeparator()}]"),
+                                "",
+                            ).replace(preferencesDataSource.getDecimalSeparator(), ".")
                         try {
-                            BigDecimal(it)
+                            BigDecimal(cleaned)
                         } catch (e: NumberFormatException) {
                             BigDecimal.ZERO
                         }
                     }
                     .fold(BigDecimal.ZERO) { l, r -> l + r }
                     .let { it.negate() }
-                    .let { if (it == BigDecimal.ZERO.setScale(it.scale())) "" else it.toString() }
+                    .let {
+                        if (it == BigDecimal.ZERO.setScale(it.scale())) {
+                            ""
+                        } else {
+                            it.toString().replace(
+                                ".",
+                                preferencesDataSource.getDecimalSeparator(),
+                            )
+                        }
+                    }
             }
 
         val valid: LiveData<Boolean> =

--- a/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
@@ -79,6 +79,11 @@ class PreferencesActivity() : ComponentActivity() {
                     true to stringResource(R.string.currency_order_before),
                     false to stringResource(R.string.currency_order_after),
                 )
+            val separatorMap =
+                mapOf(
+                    "." to stringResource(R.string.separator_point),
+                    "," to stringResource(R.string.separator_comma),
+                )
             NanoLedgerTheme {
                 Scaffold(topBar = { Bar() }) { contentPadding ->
                     Column(
@@ -159,6 +164,39 @@ class PreferencesActivity() : ComponentActivity() {
                                         onClick = {
                                             preferencesViewModel.storeDefaultStatus(it.key)
                                             expandedStatus = false
+                                        },
+                                        contentPadding =
+                                            ExposedDropdownMenuDefaults.ItemContentPadding,
+                                    )
+                                }
+                            }
+                        }
+                        HorizontalDivider()
+                        val decimalSeparator by preferencesViewModel.decimalSeparator.observeAsState()
+                        var expandedSeparator by rememberSaveable { mutableStateOf(false) }
+                        ExposedDropdownMenuBox(
+                            expanded = expandedSeparator,
+                            onExpandedChange = { expandedSeparator = !expandedSeparator },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Setting(
+                                stringResource(R.string.decimal_separator),
+                                separatorMap[decimalSeparator ?: "."] ?: stringResource(
+                                    R.string.separator_point,
+                                ),
+                                modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryEditable),
+                            ) { expandedSeparator = true }
+                            ExposedDropdownMenu(
+                                expanded = expandedSeparator,
+                                onDismissRequest = { expandedSeparator = false },
+                                modifier = Modifier.exposedDropdownSize(true),
+                            ) {
+                                separatorMap.forEach {
+                                    DropdownMenuItem(
+                                        text = { Text(it.value) },
+                                        onClick = {
+                                            preferencesViewModel.storeDecimalSeparator(it.key)
+                                            expandedSeparator = false
                                         },
                                         contentPadding =
                                             ExposedDropdownMenuDefaults.ItemContentPadding,

--- a/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesViewModel.kt
@@ -16,12 +16,15 @@ class PreferencesViewModel
         private val preferencesDataSource: PreferencesDataSource,
     ) : AndroidViewModel(application) {
         val fileUri: LiveData<Uri?> = preferencesDataSource.fileUri
+        val decimalSeparator: LiveData<String> = preferencesDataSource.decimalSeparator
         val defaultCurrency: LiveData<String> = preferencesDataSource.defaultCurrency
         val defaultStatus: LiveData<String> = preferencesDataSource.defaultStatus
         val currencyBeforeAmount: LiveData<Boolean> = preferencesDataSource.currencyBeforeAmount
         val postingWidth: LiveData<Int> = preferencesDataSource.postingWidth
 
         fun storeFileUri(uri: Uri) = preferencesDataSource.setFileUri(uri)
+
+        fun storeDecimalSeparator(separator: String) = preferencesDataSource.setDecimalSeparator(separator)
 
         fun storeDefaultCurrency(currency: String) = preferencesDataSource.setDefaultCurrency(currency)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="currency_order_after">Currency after amount</string>
     <string name="currency_order_before">Currency before amount</string>
     <string name="date">Date</string>
+    <string name="decimal_separator">Decimal separator</string>
     <string name="default_currency">Default currency</string>
     <string name="default_status">Default status</string>
     <string name="delete">Delete</string>
@@ -31,6 +32,8 @@
     <string name="posting_width">Width of postings written to file</string>
     <string name="save">Save</string>
     <string name="select_file">Select file…</string>
+    <string name="separator_point">Point (.)</string>
+    <string name="separator_comma">Comma (,)</string>
     <string name="settings">Settings</string>
     <string name="show">Show</string>
     <string name="status_cleared">Cleared (*)</string>


### PR DESCRIPTION
This is only used when parsing the numbers for showing the amount hint, other functionality is unaffected.

Fixes #78. Fixes #186.
