### PR TITLE
Store transaction notes to avoid deleting them when editing a ledger file

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
@@ -27,7 +27,7 @@ class LedgerRepository
         val accounts: LiveData<Set<String>> =
             transactions.map {
                 val result = HashSet<String>()
-                it.forEach { result.addAll(it.postings.map { it.account }) }
+                it.forEach { result.addAll(it.postings.map { it.account ?: "" }) }
                 result
             }
         val payees: LiveData<Set<String>> = transactions.map { HashSet(it.map { it.payee }) }

--- a/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
@@ -27,7 +27,7 @@ class LedgerRepository
         val accounts: LiveData<Set<String>> =
             transactions.map {
                 val result = HashSet<String>()
-                it.forEach { result.addAll(it.postings.map { it.account ?: "" }) }
+                it.forEach { result.addAll(it.postings.mapNotNull { it.account }) }
                 result
             }
         val payees: LiveData<Set<String>> = transactions.map { HashSet(it.map { it.payee }) }

--- a/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
@@ -15,5 +15,4 @@ data class Posting(
     fun isNote() = account == null && amount == null && note != ""
 
     fun isEmpty() = account == null && amount == null && note == null
-
 }

--- a/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
@@ -1,0 +1,19 @@
+package be.chvp.nanoledger.data
+
+data class Amount(val quantity: String, val currency: String, val original: String)
+
+data class Posting(
+    val account: String?,
+    val amount: Amount?,
+    val note: String?,
+) {
+    // secondary constructor for empty Posting
+    constructor() : this(null, null, null) {}
+
+    fun contains(query: String) = account?.contains(query, ignoreCase = true) ?: false
+
+    fun isNote() = account == null && amount == null && note != ""
+
+    fun isEmpty() = account == null && amount == null && note == null
+
+}

--- a/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
@@ -10,7 +10,7 @@ data class Posting(
     // secondary constructor for empty Posting
     constructor() : this(null, null, null) {}
 
-    fun contains(query: String) = account?.contains(query, ignoreCase = true) ?: false
+    fun contains(query: String) = account?.contains(query, ignoreCase = true) ?: note?.contains(query, ignoreCase = true) ?: false
 
     fun isNote() = account == null && amount == null && note != ""
 

--- a/app/src/main/java/be/chvp/nanoledger/data/Transaction.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/Transaction.kt
@@ -1,15 +1,5 @@
 package be.chvp.nanoledger.data
 
-data class Amount(val quantity: String, val currency: String, val original: String)
-
-data class Posting(
-    val account: String?,
-    val amount: Amount?,
-    val note: String?,
-) {
-    fun contains(query: String) = account?.contains(query, ignoreCase = true) ?: false
-}
-
 data class Transaction(
     val firstLine: Int,
     val lastLine: Int,

--- a/app/src/main/java/be/chvp/nanoledger/data/Transaction.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/Transaction.kt
@@ -3,10 +3,11 @@ package be.chvp.nanoledger.data
 data class Amount(val quantity: String, val currency: String, val original: String)
 
 data class Posting(
-    val account: String,
+    val account: String?,
     val amount: Amount?,
+    val note: String?,
 ) {
-    fun contains(query: String) = account.contains(query, ignoreCase = true)
+    fun contains(query: String) = account?.contains(query, ignoreCase = true) ?: false
 }
 
 data class Transaction(

--- a/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
@@ -38,7 +38,7 @@ fun extractTransactions(lines: List<String>): List<Transaction> {
     return result
 }
 
-val commentRegex = Regex("[ \\t]*;.*$")
+val commentRegex = Regex(";.*$")
 val postingSplitRegex = Regex("[ \\t]{2,}")
 
 fun extractPosting(line: String): Posting? {
@@ -47,13 +47,17 @@ fun extractPosting(line: String): Posting? {
     var amount: Amount? = null
     var note: String? = null
 
+    val trimmed = line.trim()
+
     // check if we have a note in the posting
-    val commentMatch = commentRegex.find(line)
+    val commentMatch = commentRegex.find(trimmed)
     if (commentMatch != null) {
         note = commentMatch.value
     }
 
-    val stripped = line.trim().replace(commentRegex, "")
+    // trim again the string after removing the comment, as we don't know
+    // if between the comment and the amount there is any white space
+    val stripped = trimmed.replace(commentRegex, "").trim()
     // if we have more content than just a note, continue parsing
     if (stripped.isNotEmpty()) {
         val components = stripped.split(postingSplitRegex, limit = 2)

--- a/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
@@ -38,7 +38,7 @@ fun extractTransactions(lines: List<String>): List<Transaction> {
     return result
 }
 
-val commentRegex = Regex(";.*$")
+val commentRegex = Regex("[ \\t]*;.*$")
 val postingSplitRegex = Regex("[ \\t]{2,}")
 
 fun extractPosting(line: String): Posting? {
@@ -47,17 +47,13 @@ fun extractPosting(line: String): Posting? {
     var amount: Amount? = null
     var note: String? = null
 
-    val trimmed = line.trim()
-
     // check if we have a note in the posting
-    val commentMatch = commentRegex.find(trimmed)
+    val commentMatch = commentRegex.find(line)
     if (commentMatch != null) {
         note = commentMatch.value
     }
 
-    // trim again the string after removing the comment, as we don't know
-    // if between the comment and the amount there is any white space
-    val stripped = trimmed.replace(commentRegex, "").trim()
+    val stripped = line.replace(commentRegex, "").trim()
     // if we have more content than just a note, continue parsing
     if (stripped.isNotEmpty()) {
         val components = stripped.split(postingSplitRegex, limit = 2)

--- a/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
@@ -42,16 +42,15 @@ val commentRegex = Regex("[ \\t]*;.*$")
 val postingSplitRegex = Regex("[ \\t]{2,}")
 
 fun extractPosting(line: String): Posting? {
-
     // the three components of a posting
     var account: String? = null
     var amount: Amount? = null
     var note: String? = null
 
     // check if we have a note in the posting
-    val comment_match = commentRegex.find(line)
-    if (comment_match != null) {
-        note = comment_match.value
+    val commentMatch = commentRegex.find(line)
+    if (commentMatch != null) {
+        note = commentMatch.value
     }
 
     val stripped = line.trim().replace(commentRegex, "")
@@ -64,7 +63,6 @@ fun extractPosting(line: String): Posting? {
         if (components.size > 1) {
             amount = extractAmount(components[1].trim())
         }
-
     }
 
     return Posting(account, amount, note)

--- a/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
@@ -38,21 +38,36 @@ fun extractTransactions(lines: List<String>): List<Transaction> {
     return result
 }
 
-val commentRegex = Regex(";.*$")
+val commentRegex = Regex("[ \\t]*;.*$")
 val postingSplitRegex = Regex("[ \\t]{2,}")
 
 fun extractPosting(line: String): Posting? {
+
+    // the three components of a posting
+    var account: String? = null
+    var amount: Amount? = null
+    var note: String? = null
+
+    // check if we have a note in the posting
+    val comment_match = commentRegex.find(line)
+    if (comment_match != null) {
+        note = comment_match.value
+    }
+
     val stripped = line.trim().replace(commentRegex, "")
-    if (stripped.length == 0) {
-        return null
+    // if we have more content than just a note, continue parsing
+    if (stripped.isNotEmpty()) {
+        val components = stripped.split(postingSplitRegex, limit = 2)
+        account = components[0]
+
+        // if we have more than the account, is the amount of the posting, parse it
+        if (components.size > 1) {
+            amount = extractAmount(components[1].trim())
+        }
+
     }
 
-    val components = stripped.split(postingSplitRegex, limit = 2)
-    if (components.size == 1) {
-        return Posting(components[0], null)
-    }
-
-    return Posting(components[0], extractAmount(components[1].trim()))
+    return Posting(account, amount, note)
 }
 
 val assertionRegex = Regex("=.*$")

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import be.chvp.nanoledger.R
+import be.chvp.nanoledger.ui.util.Quadruple
 import kotlinx.coroutines.launch
 
 val TRANSACTION_INDEX_KEY = "transaction_index"
@@ -141,8 +142,13 @@ fun TransactionForm(
             }
             val postings by viewModel.postings.observeAsState()
             postings?.forEachIndexed { i, posting ->
-                val showAmountHint = posting.first == "" && posting.third == ""
-                PostingRow(i, posting, showAmountHint, viewModel)
+                val isNote = posting.first == "" && posting.third == "" && posting.fourth != ""
+                // do not show notes rows in the UI
+                if (!isNote){
+                    val showAmountHint = posting.first == "" && posting.third == ""
+                    PostingRow(i, posting, showAmountHint, viewModel)
+                }
+
             }
         }
     }
@@ -271,7 +277,7 @@ fun NoteSelector(
 @Composable
 fun PostingRow(
     index: Int,
-    posting: Triple<String, String, String>,
+    posting: Quadruple<String, String, String, String>,
     showAmountHint: Boolean,
     viewModel: TransactionFormViewModel,
 ) {
@@ -308,7 +314,7 @@ fun PostingRow(
 @Composable
 fun CurrencyField(
     index: Int,
-    posting: Triple<String, String, String>,
+    posting: Quadruple<String, String, String, String>,
     viewModel: TransactionFormViewModel,
     modifier: Modifier = Modifier,
 ) {
@@ -329,7 +335,7 @@ fun CurrencyField(
 @Composable
 fun AmountField(
     index: Int,
-    posting: Triple<String, String, String>,
+    posting: Quadruple<String, String, String, String>,
     showAmountHint: Boolean,
     viewModel: TransactionFormViewModel,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
@@ -144,11 +144,10 @@ fun TransactionForm(
             postings?.forEachIndexed { i, posting ->
                 val isNote = posting.first == "" && posting.third == "" && posting.fourth != ""
                 // do not show notes rows in the UI
-                if (!isNote){
+                if (!isNote) {
                     val showAmountHint = posting.first == "" && posting.third == ""
                     PostingRow(i, posting, showAmountHint, viewModel)
                 }
-
             }
         }
     }

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -157,7 +157,6 @@ abstract class TransactionFormViewModel
             transaction.append('\n')
             // Drop last element, it should always be an empty posting (and the only empty posting)
             for (posting in postings.value!!.dropLast(1)) {
-
                 val account = posting.account ?: ""
                 val currency = posting.amount?.currency ?: ""
                 val amount = posting.amount?.quantity ?: ""
@@ -177,11 +176,11 @@ abstract class TransactionFormViewModel
                     )
                 } else if (preferencesDataSource.getCurrencyBeforeAmount()) {
                     transaction.append(
-                        "    ${account}  ${spaces}${currency} ${amount}${note}\n",
+                        "    $account  $spaces$currency $amount$note\n",
                     )
                 } else {
                     transaction.append(
-                        "    ${account}  ${spaces}${amount} ${currency}${note}\n",
+                        "    $account  $spaces$amount $currency$note\n",
                     )
                 }
             }
@@ -196,9 +195,7 @@ abstract class TransactionFormViewModel
             setStatus(transaction.status ?: "")
             setPayee(transaction.payee)
             setNote(transaction.note ?: "")
-
-            setPostings( transaction.postings )
-
+            setPostings(transaction.postings)
         }
 
         fun setDate(dateMillis: Long) {

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -260,7 +260,7 @@ abstract class TransactionFormViewModel
             val original = result[index].amount?.original ?: ""
             var newAmount: Amount? = null
 
-            if (quantity != "" || original == "" || newCurrency == "") {
+            if (quantity != "" || original != "" || newCurrency != "") {
                 newAmount = Amount(quantity, newCurrency, original)
             }
 
@@ -277,7 +277,7 @@ abstract class TransactionFormViewModel
             val original = result[index].amount?.original ?: ""
             var newAmount: Amount? = null
 
-            if (newAmountString != "" || original == "" || currency == "") {
+            if (newAmountString != "" || original != "" || currency != "") {
                 newAmount = Amount(newAmountString, currency, original)
             }
 

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -151,20 +151,29 @@ abstract class TransactionFormViewModel
             transaction.append('\n')
             // Drop last element, it should always be an empty posting (and the only empty posting)
             for (posting in postings.value!!.dropLast(1)) {
-                val usedLength = 7 + posting.first.length + posting.second.length + posting.third.length
+                val usedLength = 7 +
+                        posting.first.length +
+                        posting.second.length +
+                        posting.third.length +
+                        posting.fourth.length
+
                 val numberOfSpaces = preferencesDataSource.getPostingWidth() - usedLength
                 val spaces = " ".repeat(maxOf(0, numberOfSpaces))
-                if (posting.third == "") {
+
+                if (posting.first == "") {
+                    // this posting is a note
+                    transaction.append("${posting.fourth}\n")
+                } else if (posting.third == "") {
                     transaction.append(
-                        "    ${posting.first}\n",
+                        "    ${posting.first}${posting.fourth}\n",
                     )
                 } else if (preferencesDataSource.getCurrencyBeforeAmount()) {
                     transaction.append(
-                        "    ${posting.first}  ${spaces}${posting.second} ${posting.third}\n",
+                        "    ${posting.first}  ${spaces}${posting.second} ${posting.third}${posting.fourth}\n",
                     )
                 } else {
                     transaction.append(
-                        "    ${posting.first}  ${spaces}${posting.third} ${posting.second}\n",
+                        "    ${posting.first}  ${spaces}${posting.third} ${posting.second}${posting.fourth}\n",
                     )
                 }
             }

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -108,13 +108,16 @@ abstract class TransactionFormViewModel
                         if (payee == "") {
                             return@map false
                         }
-                        if (postings.dropLast(1).any { it.first == "" }) {
+                        if (unbalancedAmount != "" &&
+                            postings.dropLast(1).all {
+                                it.third != "" ||
+                                (it.first == "" && it.third == "" && it.fourth != "") // its a note, allow empty amount
+                            }) {
                             return@map false
                         }
-                        if (unbalancedAmount != "" && postings.dropLast(1).all { it.third != "" }) {
-                            return@map false
-                        }
-                        if (postings.dropLast(1).filter { it.third == "" }.size > 1) {
+                        if (postings.dropLast(1).filter {
+                            it.third == "" ||  (it.first == "" && it.third == "" && it.fourth != "") // its a note, allow empty amount
+                        }.size > 1) {
                             return@map false
                         }
                         return@map true

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -10,12 +10,12 @@ import be.chvp.nanoledger.data.LedgerRepository
 import be.chvp.nanoledger.data.PreferencesDataSource
 import be.chvp.nanoledger.data.Transaction
 import be.chvp.nanoledger.ui.util.Event
+import be.chvp.nanoledger.ui.util.Quadruple
 import java.io.IOException
 import java.math.BigDecimal
 import java.text.ParsePosition
 import java.text.SimpleDateFormat
 import java.util.Date
-import be.chvp.nanoledger.ui.util.Quadruple
 
 val dateFormat = SimpleDateFormat("yyyy-MM-dd")
 
@@ -111,8 +111,9 @@ abstract class TransactionFormViewModel
                         if (unbalancedAmount != "" &&
                             postings.dropLast(1).all {
                                 it.third != "" ||
-                                (it.first == "" && it.third == "" && it.fourth != "") // its a note, allow empty amount
-                            }) {
+                                    (it.first == "" && it.third == "" && it.fourth != "") // its a note, allow empty amount
+                            }
+                        ) {
                             return@map false
                         }
                         if (postings.dropLast(1).filter {
@@ -277,7 +278,7 @@ abstract class TransactionFormViewModel
 
             val filteredResult = ArrayList<Quadruple<String, String, String, String>>()
             for (quadruple in result) {
-                if ( quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "" ) {
+                if (quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "") {
                     filteredResult.add(quadruple)
                 }
             }

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -116,9 +116,11 @@ abstract class TransactionFormViewModel
                         ) {
                             return@map false
                         }
-                        if (postings.dropLast(1).filter {
-                            it.third == "" ||  (it.first == "" && it.third == "" && it.fourth != "") // its a note, allow empty amount
-                        }.size > 1) {
+                        if (
+                            postings.dropLast(1).filter {
+                                it.third == "" || (it.first == "" && it.third == "" && it.fourth != "") // its a note, allow empty amount
+                            }.size > 1
+                        ) {
                             return@map false
                         }
                         return@map true
@@ -155,11 +157,12 @@ abstract class TransactionFormViewModel
             transaction.append('\n')
             // Drop last element, it should always be an empty posting (and the only empty posting)
             for (posting in postings.value!!.dropLast(1)) {
-                val usedLength = 7 +
-                        posting.first.length +
-                        posting.second.length +
-                        posting.third.length +
-                        posting.fourth.length
+                val usedLength =
+                    7 +
+                    posting.first.length +
+                    posting.second.length +
+                    posting.third.length +
+                    posting.fourth.length
 
                 val numberOfSpaces = preferencesDataSource.getPostingWidth() - usedLength
                 val spaces = " ".repeat(maxOf(0, numberOfSpaces))
@@ -236,7 +239,7 @@ abstract class TransactionFormViewModel
             result[index] = Quadruple(newAccount, result[index].second, result[index].third, result[index].fourth)
             val filteredResult = ArrayList<Quadruple<String, String, String, String>>()
             for (quadruple in result) {
-                if ( quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "" ) {
+                if (quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "") {
                     filteredResult.add(quadruple)
                 }
             }
@@ -261,7 +264,7 @@ abstract class TransactionFormViewModel
             result[index] = Quadruple(result[index].first, result[index].second, newAmount, result[index].fourth)
             val filteredResult = ArrayList<Quadruple<String, String, String, String>>()
             for (quadruple in result) {
-                if ( quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "" ) {
+                if (quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "") {
                     filteredResult.add(quadruple)
                 }
             }

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -15,6 +15,7 @@ import java.math.BigDecimal
 import java.text.ParsePosition
 import java.text.SimpleDateFormat
 import java.util.Date
+import be.chvp.nanoledger.ui.util.Quadruple
 
 val dateFormat = SimpleDateFormat("yyyy-MM-dd")
 
@@ -61,10 +62,10 @@ abstract class TransactionFormViewModel
             }
 
         private val _postings =
-            MutableLiveData<List<Triple<String, String, String>>>(
+            MutableLiveData<List<Quadruple<String, String, String, String>>>(
                 listOf(emptyPosting()),
             )
-        val postings: LiveData<List<Triple<String, String, String>>> = _postings
+        val postings: LiveData<List<Quadruple<String, String, String, String>>> = _postings
         val accounts: LiveData<List<String>> = ledgerRepository.accounts.map { it.sorted() }
         val unbalancedAmount: LiveData<String> =
             postings.map {
@@ -180,9 +181,10 @@ abstract class TransactionFormViewModel
             setNote(transaction.note ?: "")
 
             transaction.postings.forEachIndexed { i, posting ->
-                setAccount(i, posting.account)
+                setAccount(i, posting.account ?: "")
                 setCurrency(i, posting.amount?.currency ?: "")
                 setAmount(i, posting.amount?.quantity ?: "")
+                setPostingNote(i, posting.note ?: "")
             }
         }
 
@@ -218,11 +220,11 @@ abstract class TransactionFormViewModel
             newAccount: String,
         ) {
             val result = ArrayList(postings.value!!)
-            result[index] = Triple(newAccount, result[index].second, result[index].third)
-            val filteredResult = ArrayList<Triple<String, String, String>>()
-            for (triple in result) {
-                if (triple.first != "" || triple.third != "") {
-                    filteredResult.add(triple)
+            result[index] = Quadruple(newAccount, result[index].second, result[index].third, result[index].fourth)
+            val filteredResult = ArrayList<Quadruple<String, String, String, String>>()
+            for (quadruple in result) {
+                if ( quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "" ) {
+                    filteredResult.add(quadruple)
                 }
             }
             filteredResult.add(emptyPosting())
@@ -234,7 +236,7 @@ abstract class TransactionFormViewModel
             newCurrency: String,
         ) {
             val result = ArrayList(postings.value!!)
-            result[index] = Triple(result[index].first, newCurrency, result[index].third)
+            result[index] = Quadruple(result[index].first, newCurrency, result[index].third, result[index].fourth)
             _postings.value = result
         }
 
@@ -243,18 +245,35 @@ abstract class TransactionFormViewModel
             newAmount: String,
         ) {
             val result = ArrayList(postings.value!!)
-            result[index] = Triple(result[index].first, result[index].second, newAmount)
-            val filteredResult = ArrayList<Triple<String, String, String>>()
-            for (triple in result) {
-                if (triple.first != "" || triple.third != "") {
-                    filteredResult.add(triple)
+            result[index] = Quadruple(result[index].first, result[index].second, newAmount, result[index].fourth)
+            val filteredResult = ArrayList<Quadruple<String, String, String, String>>()
+            for (quadruple in result) {
+                if ( quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "" ) {
+                    filteredResult.add(quadruple)
                 }
             }
             filteredResult.add(emptyPosting())
             _postings.value = filteredResult
         }
 
-        fun emptyPosting(): Triple<String, String, String> {
-            return Triple("", preferencesDataSource.getDefaultCurrency(), "")
+        fun setPostingNote(
+            index: Int,
+            newPostingNote: String,
+        ) {
+            val result = ArrayList(postings.value!!)
+            result[index] = Quadruple(result[index].first, result[index].second, result[index].third, newPostingNote)
+
+            val filteredResult = ArrayList<Quadruple<String, String, String, String>>()
+            for (quadruple in result) {
+                if ( quadruple.first != "" || quadruple.third != "" || quadruple.fourth != "" ) {
+                    filteredResult.add(quadruple)
+                }
+            }
+            filteredResult.add(emptyPosting())
+            _postings.value = filteredResult
+        }
+
+        fun emptyPosting(): Quadruple<String, String, String, String> {
+            return Quadruple("", preferencesDataSource.getDefaultCurrency(), "", "")
         }
     }

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -159,10 +159,10 @@ abstract class TransactionFormViewModel
             for (posting in postings.value!!.dropLast(1)) {
                 val usedLength =
                     7 +
-                    posting.first.length +
-                    posting.second.length +
-                    posting.third.length +
-                    posting.fourth.length
+                        posting.first.length +
+                        posting.second.length +
+                        posting.third.length +
+                        posting.fourth.length
 
                 val numberOfSpaces = preferencesDataSource.getPostingWidth() - usedLength
                 val spaces = " ".repeat(maxOf(0, numberOfSpaces))

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -161,8 +161,7 @@ abstract class TransactionFormViewModel
                     7 +
                         posting.first.length +
                         posting.second.length +
-                        posting.third.length +
-                        posting.fourth.length
+                        posting.third.length
 
                 val numberOfSpaces = preferencesDataSource.getPostingWidth() - usedLength
                 val spaces = " ".repeat(maxOf(0, numberOfSpaces))

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -157,11 +157,7 @@ abstract class TransactionFormViewModel
             transaction.append('\n')
             // Drop last element, it should always be an empty posting (and the only empty posting)
             for (posting in postings.value!!.dropLast(1)) {
-                val usedLength =
-                    7 +
-                        posting.first.length +
-                        posting.second.length +
-                        posting.third.length
+                val usedLength = 7 + posting.first.length + posting.second.length + posting.third.length
 
                 val numberOfSpaces = preferencesDataSource.getPostingWidth() - usedLength
                 val spaces = " ".repeat(maxOf(0, numberOfSpaces))

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
@@ -65,10 +65,11 @@ fun TransactionCard(
                     overflow = TextOverflow.Ellipsis,
                 )
                 for (p in transaction.postings) {
-                    if (p.account == null && p.note != null) {
+                    if (p.isNote()) {
+                        val trimmed_note = p.note!!.trim()
                         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
                             Text(
-                                "  ${p.note}",
+                                "  $trimmed_note",
                                 softWrap = false,
                                 style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                                 overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
@@ -66,10 +66,10 @@ fun TransactionCard(
                 )
                 for (p in transaction.postings) {
                     if (p.isNote()) {
-                        val trimmed_note = p.note!!.trim()
+                        val trimmedNote = p.note!!.trim()
                         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
                             Text(
-                                "  $trimmed_note",
+                                "  $trimmedNote",
                                 softWrap = false,
                                 style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                                 overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
@@ -75,7 +75,7 @@ fun TransactionCard(
                                 modifier = Modifier.weight(1f),
                             )
                         }
-                    } else{
+                    } else {
                         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
                             Text(
                                 "  ${p.account}",
@@ -92,7 +92,6 @@ fun TransactionCard(
                             )
                         }
                     }
-
                 }
             }
         }

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
@@ -65,21 +65,24 @@ fun TransactionCard(
                     overflow = TextOverflow.Ellipsis,
                 )
                 for (p in transaction.postings) {
-                    Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
-                        Text(
-                            "  ${p.account}",
-                            softWrap = false,
-                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Text(
-                            p.amount?.original ?: "",
-                            softWrap = false,
-                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                            modifier = Modifier.padding(start = 2.dp),
-                        )
+                    if (p.account != null) {
+                        Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                "  ${p.account}",
+                                softWrap = false,
+                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Text(
+                                p.amount?.original ?: "",
+                                softWrap = false,
+                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                modifier = Modifier.padding(start = 2.dp),
+                            )
+                        }
                     }
+
                 }
             }
         }

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
@@ -65,7 +65,17 @@ fun TransactionCard(
                     overflow = TextOverflow.Ellipsis,
                 )
                 for (p in transaction.postings) {
-                    if (p.account != null) {
+                    if (p.account == null && p.note != null) {
+                        Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                "  ${p.note}",
+                                softWrap = false,
+                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    } else{
                         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
                             Text(
                                 "  ${p.account}",

--- a/app/src/main/java/be/chvp/nanoledger/ui/util/Quadruple.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/util/Quadruple.kt
@@ -1,8 +1,0 @@
-package be.chvp.nanoledger.ui.util
-
-import java.io.Serializable
-
-data class Quadruple<A, B, C, D>(var first: A, var second: B, var third: C, var fourth: D) :
-    Serializable {
-    override fun toString(): String = "($first, $second, $third, $fourth)"
-}

--- a/app/src/main/java/be/chvp/nanoledger/ui/util/Quadruple.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/util/Quadruple.kt
@@ -2,7 +2,7 @@ package be.chvp.nanoledger.ui.util
 
 import java.io.Serializable
 
-data class Quadruple<A,B,C,D>(var first: A, var second: B, var third: C, var fourth: D):
+data class Quadruple<A, B, C, D>(var first: A, var second: B, var third: C, var fourth: D) :
     Serializable {
     override fun toString(): String = "($first, $second, $third, $fourth)"
 }

--- a/app/src/main/java/be/chvp/nanoledger/ui/util/Quadruple.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/util/Quadruple.kt
@@ -1,0 +1,8 @@
+package be.chvp.nanoledger.ui.util
+
+import java.io.Serializable
+
+data class Quadruple<A,B,C,D>(var first: A, var second: B, var third: C, var fourth: D):
+    Serializable {
+    override fun toString(): String = "($first, $second, $third, $fourth)"
+}


### PR DESCRIPTION
This PR introduces a member `note` in the `Posting` class and allows the member `account` to be null in order to store postings that are notes (does not have an account and amount associated).  To made this work I've modified the `extractPosting` method to, instead of deleting the comment, store it in the new `note` member.

As for now adding a note to a posting is not allowed, I've also disable the visualization of postings that are notes in the edit and add ViewModels.

I've displayed the notes that does not have an account and amount in the main view but I'm not sure if that can be confusing as the notes with account and amount are not displayed (but are stored and saved).


An example of a transaction with a note in the main view. The postings that starts with ! also have notes, but are not displayed.
![imagen](https://github.com/user-attachments/assets/e2da321c-233e-446d-9237-465a545f94d3)


I also changed the conditions to made a transaction valid, as now the app should allow postings with empty accounts and amounts if they are notes.


Fixes #222  .

I've manually tested both in a simple test file ([test.ledger.txt](https://github.com/user-attachments/files/18310257/test.ledger.txt)) and my own ledger file.
