### PR TITLE
Draft: Implement a way to edit postings note and status

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/Posting.kt
@@ -4,11 +4,12 @@ data class Amount(val quantity: String, val currency: String, val original: Stri
 
 data class Posting(
     val account: String?,
+    val status: String?,
     val amount: Amount?,
     val note: String?,
 ) {
     // secondary constructor for empty Posting
-    constructor(currency: String) : this(null, Amount("", currency, ""), null) {}
+    constructor(currency: String) : this(null, null, Amount("", currency, ""), null) {}
 
     fun contains(query: String) = account?.contains(query, ignoreCase = true) ?: note?.contains(query, ignoreCase = true) ?: false
 

--- a/app/src/main/java/be/chvp/nanoledger/data/PreferencesDataSource.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/PreferencesDataSource.kt
@@ -12,6 +12,7 @@ const val DECIMAL_SEPARATOR_KEY = "decimal_separator"
 const val DEFAULT_CURRENCY_KEY = "default_currency"
 const val DEFAULT_STATUS_KEY = "default_status"
 const val CURRENCY_BEFORE_AMOUNT_KEY = "currency_before_amount"
+const val DETAILED_POSTINGS = "detailed_postings"
 const val POSTING_WIDTH_KEY = "posting_width"
 
 class PreferencesDataSource
@@ -87,6 +88,24 @@ class PreferencesDataSource
             sharedPreferences.edit().putBoolean(
                 CURRENCY_BEFORE_AMOUNT_KEY,
                 currencyBeforeAmount,
+            ).apply()
+
+        val detailedPostings: LiveData<Boolean> =
+            sharedPreferences.booleanLiveData(
+                DETAILED_POSTINGS,
+                true,
+            )
+
+        fun getDetailedPostings(): Boolean =
+            sharedPreferences.getBoolean(
+                DETAILED_POSTINGS,
+                true,
+            )
+
+        fun setDetailedPostings(detailedPostings: Boolean) =
+            sharedPreferences.edit().putBoolean(
+                DETAILED_POSTINGS,
+                detailedPostings,
             ).apply()
 
         val postingWidth: LiveData<Int> = sharedPreferences.intLiveData(POSTING_WIDTH_KEY, 72).map { it!! }

--- a/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/parser/TransactionParser.kt
@@ -44,6 +44,7 @@ val postingSplitRegex = Regex("[ \\t]{2,}")
 fun extractPosting(line: String): Posting? {
     // the three components of a posting
     var account: String? = null
+    var status: String? = null
     var amount: Amount? = null
     var note: String? = null
 
@@ -59,13 +60,19 @@ fun extractPosting(line: String): Posting? {
         val components = stripped.split(postingSplitRegex, limit = 2)
         account = components[0]
 
+        // parse the status inside account
+        if (account.startsWith('*') || account.startsWith('!')) {
+            status = account[0].toString()
+            account = account.drop(1).trim()
+        }
+
         // if we have more than the account, is the amount of the posting, parse it
         if (components.size > 1) {
             amount = extractAmount(components[1].trim())
         }
     }
 
-    return Posting(account, amount, note)
+    return Posting(account, status, amount, note)
 }
 
 val assertionRegex = Regex("=.*$")

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
@@ -353,13 +353,13 @@ fun NoteField(
     modifier: Modifier = Modifier,
 ) {
 
-    val startNoteRegex = Regex("[ \\t]*;[ \\t]*")
+    val startNoteRegex = Regex("[ \\t]*;[ \\t]?")
     // save the note start in order to use the correct syntax in the ledger file
     // when saving the note.
     val noteStart = startNoteRegex.find(posting.note ?: " ; ")!!.value
 
-    // for the dialog, remove the note start and trim the result
-    val noteText = (posting.note ?: "").replace(noteStart, "").trim()
+    // for the note text, remove the note start
+    val noteText = (posting.note ?: "").replace(noteStart, "")
 
     TextField(
         value = noteText,
@@ -370,7 +370,8 @@ fun NoteField(
             // if the result trimmed is not empty, construct the full note,
             // else pass a null note as we are deleting the value
             if (trimmedNote != "") {
-                finalNote = noteStart + trimmedNote
+                // here do not use the trimmed version, as it will not allow writing spaces
+                finalNote = noteStart + it
             }
 
             viewModel.setPostingNote(index, finalNote)

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
@@ -5,6 +5,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -57,8 +58,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.lifecycle.viewmodel.compose.viewModel
 import be.chvp.nanoledger.R
 import be.chvp.nanoledger.data.Posting
 import kotlinx.coroutines.launch
@@ -139,7 +138,7 @@ fun TransactionForm(
                 verticalAlignment = Alignment.Bottom,
             ) {
                 DateSelector(viewModel, Modifier.weight(0.3f).padding(start = 4.dp, end = 2.dp).fillMaxWidth())
-                StatusSelector(viewModel, Modifier.weight(0.12f).padding(horizontal = 2.dp).fillMaxWidth())
+                StatusSelector(viewModel.status.value ?: "", Modifier.weight(0.12f).padding(horizontal = 2.dp).fillMaxWidth(), onClick = { viewModel.setStatus(it) })
                 PayeeSelector(viewModel, Modifier.weight(0.58f).padding(start = 2.dp, end = 4.dp).fillMaxWidth())
             }
             Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
@@ -204,10 +203,11 @@ fun DateSelector(
 
 @Composable
 fun StatusSelector(
-    viewModel: TransactionFormViewModel,
+    startStatus: String,
     modifier: Modifier = Modifier,
+    onClick: (newValue: String) -> Unit,
 ) {
-    val status by viewModel.status.observeAsState()
+    var status by remember { mutableStateOf(startStatus) }
     val options = listOf(" ", "!", "*")
     var expanded by rememberSaveable { mutableStateOf(false) }
     ExposedDropdownMenuBox(
@@ -216,7 +216,7 @@ fun StatusSelector(
         modifier = modifier,
     ) {
         OutlinedTextField(
-            value = (status ?: ""),
+            value = status,
             onValueChange = {},
             readOnly = true,
             modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryEditable),
@@ -236,7 +236,8 @@ fun StatusSelector(
                 DropdownMenuItem(
                     text = { Text(it) },
                     onClick = {
-                        viewModel.setStatus(it)
+                        onClick(it)
+                        status = it
                         expanded = false
                     },
                     contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
@@ -284,93 +285,72 @@ fun PostingRow(
     viewModel: TransactionFormViewModel,
 ) {
     val currencyBeforeAmount by viewModel.currencyBeforeAmount.observeAsState()
-    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp, horizontal = 2.dp)) {
-        AccountSelector(
-            index = index,
-            value = posting.account ?: "",
-            viewModel,
-            modifier = Modifier.weight(2.2f).padding(horizontal = 2.dp),
-        )
-        if (currencyBeforeAmount ?: true) {
-            CurrencyField(index, posting, viewModel, Modifier.weight(0.95f).padding(horizontal = 2.dp))
-            AmountField(
-                index,
-                posting,
-                showAmountHint,
-                viewModel,
-                Modifier.weight(1.25f).padding(horizontal = 2.dp),
-            )
-        } else {
-            AmountField(
-                index,
-                posting,
-                showAmountHint,
-                viewModel,
-                Modifier.weight(1.25f).padding(horizontal = 2.dp),
-            )
-            CurrencyField(index, posting, viewModel, Modifier.weight(0.95f).padding(horizontal = 2.dp))
+    // for some reason, the rows starts focused
+    var focusedRow by remember { mutableStateOf(true) }
+    Column(
+        modifier = Modifier.fillMaxSize().focusGroup().onFocusChanged {
+            focusedRow = !focusedRow
         }
-        ShowNoteButton(index, posting, viewModel, Modifier)
-    }
-}
-
-@Composable
-fun PostingNoteDialog(
-    onDismissRequest: () -> Unit,
-    onConfirmation: (newNoteText: String) -> Unit,
-    startText: String
-) {
-    var text by remember { mutableStateOf(startText) }
-
-    Dialog(onDismissRequest = { onDismissRequest() }) {
-        // Draw a rectangle shape with rounded corners inside the dialog
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(200.dp)
-                .padding(16.dp),
-            shape = RoundedCornerShape(16.dp),
-        ) {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                TextField(
-                    value = text,
-                    onValueChange = { text = it },
-                    label = { Text("Note") },
-                    modifier = Modifier.padding(16.dp)
+    ) {
+        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp, horizontal = 2.dp)) {
+            AccountSelector(
+                index = index,
+                value = posting.account ?: "",
+                viewModel,
+                modifier = Modifier.weight(2.2f).padding(horizontal = 2.dp),
+            )
+            if (currencyBeforeAmount ?: true) {
+                CurrencyField(index, posting, viewModel, Modifier.weight(0.95f).padding(horizontal = 2.dp))
+                AmountField(
+                    index,
+                    posting,
+                    showAmountHint,
+                    viewModel,
+                    Modifier.weight(1.25f).padding(horizontal = 2.dp),
                 )
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    TextButton(
-                        onClick = { onDismissRequest() },
-                        modifier = Modifier.padding(8.dp),
-                    ) {
-                        Text("Dismiss")
-                    }
-                    TextButton(
-                        onClick = { onConfirmation(text) },
-                        modifier = Modifier.padding(8.dp),
-                    ) {
-                        Text("Save")
-                    }
-                }
+            } else {
+                AmountField(
+                    index,
+                    posting,
+                    showAmountHint,
+                    viewModel,
+                    Modifier.weight(1.25f).padding(horizontal = 2.dp),
+                )
+                CurrencyField(index, posting, viewModel, Modifier.weight(0.95f).padding(horizontal = 2.dp))
             }
         }
+
+        if (focusedRow && viewModel.detailedPostings.value!!) {
+            PostingDetailsRow(index, posting, viewModel, Modifier.padding(16.dp))
+        }
     }
+
 }
 
 @Composable
-fun ShowNoteButton(
+fun PostingDetailsRow(
     index: Int,
     posting: Posting,
     viewModel: TransactionFormViewModel,
     modifier: Modifier
+) {
+
+    Row(
+        modifier = modifier
+    ) {
+        StatusSelector(posting.status ?: "", modifier = Modifier.weight(0.10f).padding(horizontal = 2.dp).fillMaxWidth(), onClick = {
+            viewModel.setPostingStatus(index, it)
+        })
+        NoteField(index, posting, viewModel, modifier = Modifier.weight(0.58f).padding(start = 4.dp, end = 4.dp).fillMaxWidth())
+    }
+}
+
+@Composable
+fun NoteField(
+    index: Int,
+    posting: Posting,
+    viewModel: TransactionFormViewModel,
+    modifier: Modifier = Modifier,
 ) {
 
     val startNoteRegex = Regex("[ \\t]*;[ \\t]*")
@@ -381,36 +361,31 @@ fun ShowNoteButton(
     // for the dialog, remove the note start and trim the result
     val noteText = (posting.note ?: "").replace(noteStart, "").trim()
 
-    var showPostingNoteDialog by remember { mutableStateOf(false) }
+    TextField(
+        value = noteText,
+        onValueChange = {
+            var finalNote: String? = null
+            val trimmedNote = it.trim()
 
-    Button(
-        onClick = { showPostingNoteDialog = true } ,
-        modifier = modifier
-    ) {
-        Text("\uD83D\uDCDD")
-    }
+            // if the result trimmed is not empty, construct the full note,
+            // else pass a null note as we are deleting the value
+            if (trimmedNote != "") {
+                finalNote = noteStart + trimmedNote
+            }
 
-    if (showPostingNoteDialog) {
-        PostingNoteDialog(
-            onConfirmation = { newNote: String ->
-
-                var finalNote: String? = null
-                val trimmedNote = newNote.trim()
-
-                // if the result trimmed is not empty, construct the full note,
-                // else pass a null note as we are deleting the value
-                if (trimmedNote != "") {
-                    finalNote = noteStart + trimmedNote
-                }
-
-                viewModel.setPostingNote(index, finalNote)
-                showPostingNoteDialog = false
-             },
-            onDismissRequest = { showPostingNoteDialog = false },
-            startText = noteText
+            viewModel.setPostingNote(index, finalNote)
+        },
+        label = { Text("Note") },
+        singleLine = true,
+        modifier = modifier,
+        colors =
+        ExposedDropdownMenuDefaults.textFieldColors(
+            focusedContainerColor = MaterialTheme.colorScheme.surface,
+            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
         )
-    }
+    )
 }
+
 
 @Composable
 fun CurrencyField(

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
@@ -6,23 +6,17 @@ import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DropdownMenu
@@ -138,7 +132,11 @@ fun TransactionForm(
                 verticalAlignment = Alignment.Bottom,
             ) {
                 DateSelector(viewModel, Modifier.weight(0.3f).padding(start = 4.dp, end = 2.dp).fillMaxWidth())
-                StatusSelector(viewModel.status.value ?: "", Modifier.weight(0.12f).padding(horizontal = 2.dp).fillMaxWidth(), onClick = { viewModel.setStatus(it) })
+                StatusSelector(
+                    viewModel.status.value ?: "",
+                    Modifier.weight(0.12f).padding(horizontal = 2.dp).fillMaxWidth(),
+                    onClick = { viewModel.setStatus(it) },
+                )
                 PayeeSelector(viewModel, Modifier.weight(0.58f).padding(start = 2.dp, end = 4.dp).fillMaxWidth())
             }
             Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
@@ -285,12 +283,14 @@ fun PostingRow(
     viewModel: TransactionFormViewModel,
 ) {
     val currencyBeforeAmount by viewModel.currencyBeforeAmount.observeAsState()
-    // for some reason, the rows starts focused
-    var focusedRow by remember { mutableStateOf(true) }
+    var focusedRow by remember { mutableStateOf(false) }
     Column(
-        modifier = Modifier.fillMaxSize().focusGroup().onFocusChanged {
-            focusedRow = !focusedRow
-        }
+        modifier =
+            Modifier.fillMaxSize()
+                .focusGroup()
+                .onFocusChanged({
+                    focusedRow = it.isFocused
+                }),
     ) {
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp, horizontal = 2.dp)) {
             AccountSelector(
@@ -324,7 +324,6 @@ fun PostingRow(
             PostingDetailsRow(index, posting, viewModel, Modifier.padding(16.dp))
         }
     }
-
 }
 
 @Composable
@@ -332,11 +331,10 @@ fun PostingDetailsRow(
     index: Int,
     posting: Posting,
     viewModel: TransactionFormViewModel,
-    modifier: Modifier
+    modifier: Modifier,
 ) {
-
     Row(
-        modifier = modifier
+        modifier = modifier,
     ) {
         StatusSelector(posting.status ?: "", modifier = Modifier.weight(0.10f).padding(horizontal = 2.dp).fillMaxWidth(), onClick = {
             viewModel.setPostingStatus(index, it)
@@ -352,7 +350,6 @@ fun NoteField(
     viewModel: TransactionFormViewModel,
     modifier: Modifier = Modifier,
 ) {
-
     val startNoteRegex = Regex("[ \\t]*;[ \\t]?")
     // save the note start in order to use the correct syntax in the ledger file
     // when saving the note.
@@ -380,13 +377,12 @@ fun NoteField(
         singleLine = true,
         modifier = modifier,
         colors =
-        ExposedDropdownMenuDefaults.textFieldColors(
-            focusedContainerColor = MaterialTheme.colorScheme.surface,
-            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-        )
+            ExposedDropdownMenuDefaults.textFieldColors(
+                focusedContainerColor = MaterialTheme.colorScheme.surface,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+            ),
     )
 }
-
 
 @Composable
 fun CurrencyField(

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -275,7 +275,7 @@ abstract class TransactionFormViewModel
 
         fun setPostingNote(
             index: Int,
-            newPostingNote: String,
+            newPostingNote: String?,
         ) {
             val result = ArrayList(postings.value!!)
             result[index] = Posting(result[index].account, result[index].amount, newPostingNote)

--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormViewModel.kt
@@ -292,7 +292,7 @@ abstract class TransactionFormViewModel
 
         fun setPostingStatus(
             index: Int,
-            newStatus: String?
+            newStatus: String?,
         ) {
             val result = ArrayList(postings.value!!)
             result[index] = Posting(result[index].account, newStatus, result[index].amount, result[index].note)

--- a/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/main/TransactionCard.kt
@@ -77,9 +77,10 @@ fun TransactionCard(
                             )
                         }
                     } else {
+                        val fullAccount = "${p.status ?: ""} ${p.account}".trim()
                         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
                             Text(
-                                "  ${p.account}",
+                                "  $fullAccount",
                                 softWrap = false,
                                 style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                                 overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
@@ -254,7 +254,7 @@ class PreferencesActivity() : ComponentActivity() {
                             modifier = Modifier.fillMaxWidth(),
                         ) {
                             Setting(
-                                stringResource(R.string.currency_amount_order),
+                                stringResource(R.string.posting_details),
                                 postingsInfoMap[detailedPostings ?: true] ?: stringResource(
                                     R.string.basic_postings,
                                 ),
@@ -273,7 +273,7 @@ class PreferencesActivity() : ComponentActivity() {
                                             expandedDetailedPostings = false
                                         },
                                         contentPadding =
-                                        ExposedDropdownMenuDefaults.ItemContentPadding,
+                                            ExposedDropdownMenuDefaults.ItemContentPadding,
                                     )
                                 }
                             }

--- a/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
@@ -80,6 +80,11 @@ class PreferencesActivity() : ComponentActivity() {
                     true to stringResource(R.string.currency_order_before),
                     false to stringResource(R.string.currency_order_after),
                 )
+            val postingsInfoMap =
+                mapOf(
+                    true to stringResource(R.string.detailed_postings),
+                    false to stringResource(R.string.basic_postings),
+                )
             val separatorMap =
                 mapOf(
                     "." to stringResource(R.string.separator_point),
@@ -235,6 +240,40 @@ class PreferencesActivity() : ComponentActivity() {
                                         },
                                         contentPadding =
                                             ExposedDropdownMenuDefaults.ItemContentPadding,
+                                    )
+                                }
+                            }
+                        }
+                        HorizontalDivider()
+                        val detailedPostings by
+                            preferencesViewModel.detailedPostings.observeAsState()
+                        var expandedDetailedPostings by rememberSaveable { mutableStateOf(false) }
+                        ExposedDropdownMenuBox(
+                            expanded = expandedDetailedPostings,
+                            onExpandedChange = { expandedDetailedPostings = !expandedDetailedPostings },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Setting(
+                                stringResource(R.string.currency_amount_order),
+                                postingsInfoMap[detailedPostings ?: true] ?: stringResource(
+                                    R.string.basic_postings,
+                                ),
+                                modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryEditable),
+                            ) { expandedDetailedPostings = true }
+                            ExposedDropdownMenu(
+                                expanded = expandedDetailedPostings,
+                                onDismissRequest = { expandedDetailedPostings = false },
+                                modifier = Modifier.exposedDropdownSize(true),
+                            ) {
+                                postingsInfoMap.forEach {
+                                    DropdownMenuItem(
+                                        text = { Text(it.value) },
+                                        onClick = {
+                                            preferencesViewModel.storeDetailedPostings(it.key)
+                                            expandedDetailedPostings = false
+                                        },
+                                        contentPadding =
+                                        ExposedDropdownMenuDefaults.ItemContentPadding,
                                     )
                                 }
                             }

--- a/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesViewModel.kt
@@ -20,6 +20,7 @@ class PreferencesViewModel
         val defaultCurrency: LiveData<String> = preferencesDataSource.defaultCurrency
         val defaultStatus: LiveData<String> = preferencesDataSource.defaultStatus
         val currencyBeforeAmount: LiveData<Boolean> = preferencesDataSource.currencyBeforeAmount
+        val detailedPostings: LiveData<Boolean> = preferencesDataSource.detailedPostings
         val postingWidth: LiveData<Int> = preferencesDataSource.postingWidth
 
         fun storeFileUri(uri: Uri) = preferencesDataSource.setFileUri(uri)
@@ -32,6 +33,11 @@ class PreferencesViewModel
 
         fun storeCurrencyBeforeAmount(enable: Boolean) =
             preferencesDataSource.setCurrencyBeforeAmount(
+                enable,
+            )
+
+        fun storeDetailedPostings(enable: Boolean) =
+            preferencesDataSource.setDetailedPostings(
                 enable,
             )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="default_currency">Default currency</string>
     <string name="default_status">Default status</string>
     <string name="delete">Delete</string>
+    <string name="posting_details">Posting details</string>
+    <string name="detailed_postings">Detailed postings (also shows status and note)</string>
+    <string name="basic_postings">Basic postings (only account, amount and currency)</string>
     <string name="dismiss">Dismiss</string>
     <string name="edit">Edit</string>
     <string name="edit_transaction">Edit transaction</string>


### PR DESCRIPTION
This PR introduces a new option called "Posting details" with two choices, basic posting and detailed posting. When selecting basic posting, NanoLedger works as for now, and when selecting "Detailed posting", when editing a posting a new row for editing the posting note and status will appear on the selected row:

<img src="https://github.com/user-attachments/assets/a52a9326-7d14-401a-8862-399b4b2fa9fc" width=30% />
<img src="https://github.com/user-attachments/assets/ae409866-5a1f-48e8-bb6d-7d06c6d9cfbe" width=30% />

I also added the necessary parts in the parser to parse the posting status. For now I will set the PR as draft as I still need to write the parser tests.

Fixes #229 

