### PR TITLE
Use KeyboardType.Number instead of Decimal

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/common/TransactionFormComponents.kt
@@ -357,7 +357,7 @@ fun AmountField(
                 )
             }
         },
-        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Decimal),
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
         modifier = modifier,
         textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
     )


### PR DESCRIPTION
With `KeyboardType.Number`, the Samsung keyboard allows entering the minus sign with a double-tap on the dot key. Decimals can also be input as before. See the screenshot below, taken from a Samsung Galaxy A54 5G.


| Before                                                                                                       | After                                                                                                        |
|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
| ![-5809951189750188931_121](https://github.com/user-attachments/assets/2db3fec0-ed21-4f34-bf9c-9e329d15ae99) | ![-5809951189750188935_121](https://github.com/user-attachments/assets/478cb373-447c-4f8e-b2c2-834d6aea72a3) |




Fixes #262.
