### PR TITLE
Add documentation comments to CostType enum

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/data/CostType.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/CostType.kt
@@ -1,5 +1,9 @@
 package be.chvp.nanoledger.data
 
+/**
+ * Represents the type of cost in ledger entries.
+ * UNIT denotes unit cost, TOTAL denotes total cost.
+ */
 enum class CostType(
     val repr: String,
 ) {


### PR DESCRIPTION
## Problem Background
The public enum class `CostType` lacks documentation comments, which reduces code readability and maintainability. Other developers may find it challenging to understand the purpose and values of this enum without proper documentation, potentially leading to confusion in its usage.

## Changes
Added KDoc comments to the `CostType` enum class to describe its representation and the meaning of its values:
- `UNIT` represents unit cost (denoted by '@')
- `TOTAL` represents total cost (denoted by '@@')

This improvement enhances code clarity and aids in maintaining consistent understanding across the codebase.

## Verification
These changes are purely documentation-based and do not alter functionality or API. Verification can be done by:
1. Building the project to ensure no compilation errors are introduced.
2. Reviewing the comments in the code to confirm they accurately reflect the enum's behavior and are well-formatted.