### PR TITLE
Revert "Run CI on merge group trigger"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
     tags:
       - '*'
   pull_request:
-  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
This reverts commit 7d07d0028e3ce1be752b1ef3f2bb98b8eab2f566. Turns out merge queues aren't even available in personal repositories :slightly_frowning_face: 