### PR TITLE
Work-around for nextcloud NPE when accessing file in removed account

### DIFF
--- a/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
+++ b/app/src/main/java/be/chvp/nanoledger/data/LedgerRepository.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.map
 import be.chvp.nanoledger.data.parser.extractTransactions
 import java.io.BufferedReader
 import java.io.IOException
+import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import javax.inject.Inject
@@ -174,8 +175,17 @@ class LedgerRepository
         ) {
             try {
                 val result = ArrayList<String>()
-                fileUri
-                    .let { context.contentResolver.openInputStream(it) }
+                val contentResolver = context.contentResolver!!
+                var inputStream: InputStream?
+                try {
+                    inputStream = contentResolver.openInputStream(fileUri)
+                } catch (e: NullPointerException) {
+                    // Work-around for Nextcloud throwing a NullPointerException
+                    // when accessing a file from a removed account.
+                    onReadError(e)
+                    return
+                }
+                inputStream
                     ?.let { BufferedReader(InputStreamReader(it)) }
                     ?.use { reader ->
                         var line = reader.readLine()

--- a/metadata/en-US/changelogs/next.txt
+++ b/metadata/en-US/changelogs/next.txt
@@ -1,0 +1,1 @@
+Add work-around for Nextcloud bug when trying to access a file in a logged-out account


### PR DESCRIPTION
The workaround is kept as narrow as possible to not mask any other bugs.

Fixes #459.
