### PR TITLE
Pick directory tree first before picking file

### DIFF
--- a/app/src/androidTest/java/be/chvp/nanoledger/utils/FileManagerRule.kt
+++ b/app/src/androidTest/java/be/chvp/nanoledger/utils/FileManagerRule.kt
@@ -44,6 +44,7 @@ class FileManagerRule(
 
         composeRule.onNodeWithContentDescription(context.getString(R.string.settings)).assertIsDisplayed().performClick()
         composeRule.onNodeWithText("Select file…").assertIsDisplayed().performClick()
+        composeRule.onNodeWithText("OK").assertIsDisplayed().performClick()
 
         waitForPicker()
 

--- a/app/src/androidTest/java/be/chvp/nanoledger/utils/FileManagerRule.kt
+++ b/app/src/androidTest/java/be/chvp/nanoledger/utils/FileManagerRule.kt
@@ -47,9 +47,14 @@ class FileManagerRule(
 
         waitForPicker()
 
-        device.findObject(By.descContains("Show roots")).click()
-        device.wait(Until.hasObject(By.text("Downloads")), 3_000)
-        device.findObject(By.text("Downloads")).click()
+        device.wait(Until.hasObject(By.text("Download")), 3_000)
+        device.findObject(By.text("Download")).click()
+        device.wait(Until.hasObject(By.text("some folder")), 3_000)
+        device.findObject(By.text("some folder")).click()
+        device.wait(Until.hasObject(By.text("USE THIS FOLDER")), 3_000)
+        device.findObject(By.text("USE THIS FOLDER")).click()
+        device.wait(Until.hasObject(By.text("ALLOW")), 3_000)
+        device.findObject(By.text("ALLOW")).click()
         device.wait(Until.hasObject(By.text(filename)), 5_000)
         device.findObject(By.text(filename)).click()
 
@@ -76,6 +81,7 @@ class FileManagerRule(
 
         val values =
             ContentValues().apply {
+                put(MediaStore.MediaColumns.RELATIVE_PATH, "Download/some folder")
                 put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
                 put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
             }

--- a/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
@@ -4,10 +4,12 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.provider.DocumentsContract
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocument
+import androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree
 import androidx.activity.viewModels
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -58,14 +60,24 @@ class PreferencesActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        var treeUri: Uri? = null
         val openFile =
             registerForActivityResult(OpenDocument()) { uri: Uri? ->
-                if (uri != null) {
+                if (uri != null && treeUri != null) {
+                    val documentId = DocumentsContract.getDocumentId(uri)
+                    val documentUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
+                    preferencesViewModel.storeFileUri(documentUri)
+                }
+            }
+        val openFileTree =
+            registerForActivityResult(OpenDocumentTree()) { openedTreeUri: Uri? ->
+                treeUri = openedTreeUri
+                if (treeUri != null) {
                     contentResolver.takePersistableUriPermission(
-                        uri,
+                        treeUri!!,
                         Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
                     )
-                    preferencesViewModel.storeFileUri(uri)
+                    openFile.launch(arrayOf("*/*"))
                 }
             }
         setContent {
@@ -103,7 +115,7 @@ class PreferencesActivity : ComponentActivity() {
                             stringResource(R.string.file),
                             fileUri?.toString() ?: stringResource(R.string.select_file),
                         ) {
-                            openFile.launch(arrayOf("*/*"))
+                            openFileTree.launch(null)
                         }
                         HorizontalDivider()
                         val transactionDefaultElements by preferencesViewModel.transactionDefaultElements.observeAsState(emptyList())

--- a/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
+++ b/app/src/main/java/be/chvp/nanoledger/ui/preferences/PreferencesActivity.kt
@@ -111,11 +111,30 @@ class PreferencesActivity : ComponentActivity() {
                                 .verticalScroll(rememberScrollState()),
                     ) {
                         val fileUri by preferencesViewModel.fileUri.observeAsState()
+                        var fileConfirmDialogOpen by remember { mutableStateOf(false) }
+                        if (fileConfirmDialogOpen) {
+                            AlertDialog(
+                                onDismissRequest = { fileConfirmDialogOpen = false },
+                                title = {},
+                                text = {
+                                    Text(stringResource(R.string.file_picker_explanation))
+                                },
+                                dismissButton = {},
+                                confirmButton = {
+                                    TextButton(onClick = {
+                                        openFileTree.launch(null)
+                                        fileConfirmDialogOpen = false
+                                    }) {
+                                        Text(stringResource(R.string.ok))
+                                    }
+                                },
+                            )
+                        }
                         Setting(
                             stringResource(R.string.file),
                             fileUri?.toString() ?: stringResource(R.string.select_file),
                         ) {
-                            openFileTree.launch(null)
+                            fileConfirmDialogOpen = true
                         }
                         HorizontalDivider()
                         val transactionDefaultElements by preferencesViewModel.transactionDefaultElements.observeAsState(emptyList())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="error_reading_file">Error while reading file</string>
     <string name="error_writing_file">Error while writing file</string>
     <string name="file">File</string>
+    <string name="file_picker_explanation">First, pick the folder containing the file you want to use. Then pick the actual file. NanoLedger needs access to the directory due to Android security restrictions. Only the file you pick will ever be read from or written to.</string>
     <string name="go_to_settings">Go to the settings to configure one.</string>
     <string name="mismatch_no_delete">File contents outdated, aborting delete</string>
     <string name="mismatch_no_write">File contents outdated, aborting write</string>

--- a/metadata/en-US/changelogs/next.txt
+++ b/metadata/en-US/changelogs/next.txt
@@ -1,1 +1,2 @@
 Add work-around for Nextcloud bug when trying to access a file in a logged-out account
+Add work-around for recent android security fix where access to a file is lost when it is overwritten


### PR DESCRIPTION
This should work around a recent android security fix where access to a file is lost when it is overwritten.

<!---
  Thanks for contributing to NanoLedger!  Make sure all GitHub actions
  (test, lint & build) will pass and fill out the template.

  If any changes to your PR are necessary, we will ask for them
  throughout the review process.
  --->
 
<!---
  Please include a summary of the change and which issue is
  fixed. Please also include relevant motivation and context. If your
  pull request includes visual changes (which will probably be the
  case for anything that isn't a pure logic fix), please include
  screenshots showing those changes.
  --->

Fixes #458.

<!---
  If you did any manual testing (please do so), describe here what you
  tested and how. Provide instructions so that your tests can be
  easily run again by a maintainer.
  --->
